### PR TITLE
Fixed a bug in typename dropping references and improving node events.

### DIFF
--- a/cabin.toml
+++ b/cabin.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flow-core"
-version = "0.1.0"
-authors = ["Tomas Rigaux <trigaux@cisco.com>"]
+version = "1.1.1"
+authors = ["Scott Henning <shenning@cisco.com>", "Tomas Rigaux <trigaux@cisco.com>"]
 edition = "20"
 
 [dependencies]

--- a/include/flow/core/Node.hpp
+++ b/include/flow/core/Node.hpp
@@ -139,11 +139,11 @@ class Node
     virtual json SaveInputs() const { return {}; }
     virtual void RestoreInputs(const json&) {}
 
-  private:
+  protected:
     void AddInput(std::string_view key, const std::string& caption, std::string_view type, SharedNodeData data);
+
     void AddOutput(std::string_view key, const std::string& caption, std::string_view type, SharedNodeData data);
 
-  protected:
     template<typename T>
     void AddInput(std::string_view key, const std::string& caption, SharedNodeData data = nullptr)
     {
@@ -162,14 +162,14 @@ class Node
         return AddOutput(key, caption, TypeName_v<T>, std::move(data));
     }
 
-    void EmitUpdate(const IndexableName& key);
+    void EmitUpdate(const IndexableName& key, const SharedNodeData& data);
 
   public:
     EventDispatcher<> OnCompute;
-    EventDispatcher<const IndexableName&> OnSetInput;
-    EventDispatcher<const IndexableName&> OnSetOutput;
+    EventDispatcher<const IndexableName&, const SharedNodeData&> OnSetInput;
+    EventDispatcher<const IndexableName&, const SharedNodeData&> OnSetOutput;
     EventDispatcher<const std::exception&> OnError;
-    EventDispatcher<const UUID&, const IndexableName&, SharedNodeData> OnEmitOutput;
+    EventDispatcher<const UUID&, const IndexableName&, const SharedNodeData&> OnEmitOutput;
 
   protected:
     mutable std::mutex _mutex;

--- a/include/flow/core/TypeName.hpp
+++ b/include/flow/core/TypeName.hpp
@@ -22,7 +22,6 @@ template<>
 struct TypeName<void>
 {
     static constexpr std::string_view value = "void";
-    static constexpr bool Check(std::string_view v) { return v == value; }
 };
 
 namespace detail
@@ -59,7 +58,7 @@ struct TypeName
      * @brief The string representation of the given type.
      */
     static constexpr std::string_view value = [] {
-        constexpr auto wrapped_name    = detail::wrapped_type_name<typename std::remove_cvref_t<T>>();
+        constexpr auto wrapped_name    = detail::wrapped_type_name<T>();
         constexpr auto prefix_length   = detail::wrapped_type_name_prefix_length();
         constexpr auto suffix_length   = detail::wrapped_type_name_suffix_length();
         constexpr auto TypeName_length = wrapped_name.length() - prefix_length - suffix_length;
@@ -75,17 +74,17 @@ struct TypeName
 template<typename T, typename U>
 constexpr bool operator==(const TypeName<T>&, const TypeName<U>&)
 {
-    return false;
-}
-
-template<typename T>
-constexpr bool operator==(const TypeName<T>&, const TypeName<T>&)
-{
-    return true;
+    return std::is_same_v<T, U>;
 }
 
 template<typename T>
 constexpr bool operator==(const TypeName<T>& type_name, const std::string_view& type_string)
+{
+    return type_name.value == type_string;
+}
+
+template<typename T>
+constexpr bool operator==(const std::string_view& type_string, const TypeName<T>& type_name)
 {
     return type_name.value == type_string;
 }

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -27,6 +27,10 @@ catch (const std::exception& e)
 {
     OnError.Broadcast(e);
 }
+catch (const std::string& e)
+{
+    OnError.Broadcast(std::runtime_error(e));
+}
 catch (...)
 {
     OnError.Broadcast(std::exception());
@@ -81,9 +85,9 @@ const SharedNodeData& Node::GetOutputData(const IndexableName& key) const { retu
 
 void Node::SetInputData(const IndexableName& key, SharedNodeData data, bool compute)
 {
-    _input_ports.at(key)->SetData(std::move(data));
+    _input_ports.at(key)->SetData(data);
 
-    OnSetInput.Broadcast(key);
+    OnSetInput.Broadcast(key, data);
 
     if (compute)
     {
@@ -93,20 +97,16 @@ void Node::SetInputData(const IndexableName& key, SharedNodeData data, bool comp
 
 void Node::SetOutputData(const IndexableName& key, SharedNodeData data, bool emit)
 {
-    _output_ports.at(key)->SetData(std::move(data), true);
+    _output_ports.at(key)->SetData(data, true);
 
-    OnSetOutput.Broadcast(key);
+    OnSetOutput.Broadcast(key, data);
 
     if (emit)
     {
-        EmitUpdate(key);
+        EmitUpdate(key, data);
     }
 }
 
-void Node::EmitUpdate(const IndexableName& key)
-{
-    auto data = GetOutputData(key);
-    OnEmitOutput.Broadcast(ID(), key, std::move(data));
-}
+void Node::EmitUpdate(const IndexableName& key, const SharedNodeData& data) { OnEmitOutput.Broadcast(ID(), key, data); }
 
 FLOW_NAMESPACE_END

--- a/tests/type_name_test.cpp
+++ b/tests/type_name_test.cpp
@@ -51,8 +51,13 @@ TEST(TypeNameTest, AliasTypes)
 
 TEST(TypeNameTest, ReferenceTypes)
 {
+#ifdef FLOW_APPLE
+    EXPECT_EQ(TypeName<int&>::value, "int &");
+    EXPECT_EQ(TypeName<const int&>::value, "const int &");
+#else
     EXPECT_EQ(TypeName<int&>::value, "int&");
     EXPECT_EQ(TypeName<const int&>::value, "const int&");
+#endif
 }
 
 struct TestType;

--- a/tests/type_name_test.cpp
+++ b/tests/type_name_test.cpp
@@ -49,13 +49,18 @@ TEST(TypeNameTest, AliasTypes)
     EXPECT_EQ(TypeName<alias_type>::value, "int");
 }
 
-struct TestType
+TEST(TypeNameTest, ReferenceTypes)
 {
-};
+    EXPECT_EQ(TypeName<int&>::value, "int&");
+    EXPECT_EQ(TypeName<const int&>::value, "const int&");
+}
+
+struct TestType;
 namespace TestNS
 {
 struct TestType;
 }
+
 TEST(TypeNameTest, CustomTypes)
 {
     EXPECT_EQ(TypeName<TestType>::value, "TestType");


### PR DESCRIPTION
Improved `Node` events by passing the `NodeData` as a reference to the event instead of forcing events to lookup the data in the event callback. Also fixed `TypeName` removing reference and `const` qualifiers from given types. If that behaviour is desired, then `TypeName` can be called with `std::decay_t`:
```cpp
TypeName<int&>::value; // should output "int&"
TypeName<const int&>::value; // should output "const int&"
TypeName<std::decay_t<const int&>>::value; // should output "int"