### PR TITLE
Reject type-incompatible connections in CanConnectNode

### DIFF
--- a/include/flow/core/Graph.hpp
+++ b/include/flow/core/Graph.hpp
@@ -149,7 +149,7 @@ class Graph
      * @brief Check if the nodes can be connected
      */
     bool CanConnectNode(const UUID& start, const IndexableName& start_key, const UUID& end,
-                                  const IndexableName& end_key);
+                        const IndexableName& end_key);
 
     /**
      * @brief Connects 2 nodes by their IDs and Port keys.

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -216,6 +216,9 @@ bool Graph::CanConnectNode(const UUID& start, const IndexableName& start_key, co
     const auto end_port = end_node->GetInputPort(end_key);
     if (!end_port) return false;
 
+    if (!_env->GetFactory()->IsConvertible(start_port->GetDataType(), end_port->GetDataType()))
+        return false;
+
     // Check if the end port is already connected
     if (end_port->IsConnected())
     {

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -201,11 +201,11 @@ std::vector<SharedNode> Graph::GetOrphanNodes() const
 }
 
 bool Graph::CanConnectNode(const UUID& start, const IndexableName& start_key, const UUID& end,
-                          const IndexableName& end_key)
+                           const IndexableName& end_key)
 {
     // Check if both nodes exist
     auto start_node = GetNode(start);
-    auto end_node = GetNode(end);
+    auto end_node   = GetNode(end);
     if (!(start_node && end_node)) return false;
 
     // Check if the start node has the specified output port
@@ -216,18 +216,17 @@ bool Graph::CanConnectNode(const UUID& start, const IndexableName& start_key, co
     const auto end_port = end_node->GetInputPort(end_key);
     if (!end_port) return false;
 
-    if (!_env->GetFactory()->IsConvertible(start_port->GetDataType(), end_port->GetDataType()))
-        return false;
+    if (!_env->GetFactory()->IsConvertible(start_port->GetDataType(), end_port->GetDataType())) return false;
 
     // Check if the end port is already connected
     if (end_port->IsConnected())
     {
         // Check if it's already connected to the same start port
-        auto conns = _connections.FindConnections(start, start_key);
+        auto conns      = _connections.FindConnections(start, start_key);
         auto found_conn = std::find_if(conns.begin(), conns.end(), [&](const auto& conn) {
             return conn->EndNodeID() == end && conn->EndPortKey() == end_key;
         });
-        
+
         // If already connected to the same ports, consider it as "can connect" (no-op)
         return found_conn != conns.end();
     }
@@ -272,7 +271,7 @@ SharedConnection Graph::ConnectNodes(const UUID& start_id, const IndexableName& 
 
     // Create the connection
     auto&& conn = _connections.Add(start_id, start_port->GetVarName(), end_id, end_port->GetVarName());
-    
+
     // Propagate existing data if any
     if (auto data = in_node->GetOutputData(start_port_key))
     {

--- a/tests/graph_test.cpp
+++ b/tests/graph_test.cpp
@@ -38,6 +38,25 @@ struct TestNode : public Node
         }
     }
 };
+
+struct MultiTypeNode : public Node
+{
+    MultiTypeNode() : Node(UUID{}, TypeName_v<MultiTypeNode>, "MultiType", env)
+    {
+        AddInput<int>("int_in", "");
+        AddInput<bool>("bool_in", "");
+        AddInput<std::string>("string_in", "");
+        AddInput<double>("double_in", "");
+        AddInput<std::int64_t>("int64_in", "");
+        AddOutput<int>("int_out", "");
+        AddOutput<bool>("bool_out", "");
+        AddOutput<std::string>("string_out", "");
+        AddOutput<double>("double_out", "");
+        AddOutput<std::int64_t>("int64_out", "");
+    }
+
+    void Compute() override {}
+};
 } // namespace
 
 TEST(GraphTest, Construction) { ASSERT_NO_THROW(auto graph = std::make_shared<Graph>("test", env)); }
@@ -146,6 +165,60 @@ TEST(GraphTest, PropagateConnectionData)
 
     EXPECT_EQ(node2->GetInputData<int>("in")->Get(), 101);
     EXPECT_EQ(node2->GetInputData<int>("other_in")->Get(), 202);
+}
+
+TEST(GraphTest, CanConnectNode_AcceptsMatchingTypes)
+{
+    auto graph = std::make_shared<Graph>("test", env);
+    auto a     = std::make_shared<MultiTypeNode>();
+    auto b     = std::make_shared<MultiTypeNode>();
+    graph->AddNode(a);
+    graph->AddNode(b);
+
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "int_out", b->ID(), "int_in"));
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "string_out", b->ID(), "string_in"));
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "bool_out", b->ID(), "bool_in"));
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "double_out", b->ID(), "double_in"));
+}
+
+TEST(GraphTest, CanConnectNode_RejectsHeterogeneousTypes)
+{
+    auto graph = std::make_shared<Graph>("test", env);
+    auto a     = std::make_shared<MultiTypeNode>();
+    auto b     = std::make_shared<MultiTypeNode>();
+    graph->AddNode(a);
+    graph->AddNode(b);
+
+    EXPECT_FALSE(graph->CanConnectNode(a->ID(), "bool_out", b->ID(), "string_in"));
+    EXPECT_FALSE(graph->CanConnectNode(a->ID(), "string_out", b->ID(), "double_in"));
+    EXPECT_FALSE(graph->CanConnectNode(a->ID(), "double_out", b->ID(), "bool_in"));
+}
+
+TEST(GraphTest, CanConnectNode_AcceptsRegisteredConversion)
+{
+    // Env::Create pre-registers a complete conversion mesh across the integer
+    // family, so int -> int64_t must remain a valid link.
+    auto graph = std::make_shared<Graph>("test", env);
+    auto a     = std::make_shared<MultiTypeNode>();
+    auto b     = std::make_shared<MultiTypeNode>();
+    graph->AddNode(a);
+    graph->AddNode(b);
+
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "int_out", b->ID(), "int64_in"));
+    EXPECT_TRUE(graph->CanConnectNode(a->ID(), "int64_out", b->ID(), "int_in"));
+}
+
+TEST(GraphTest, ConnectNodes_RejectsHeterogeneousPair)
+{
+    auto graph = std::make_shared<Graph>("test", env);
+    auto a     = std::make_shared<MultiTypeNode>();
+    auto b     = std::make_shared<MultiTypeNode>();
+    graph->AddNode(a);
+    graph->AddNode(b);
+
+    auto conn = graph->ConnectNodes(a->ID(), "bool_out", b->ID(), "string_in");
+    EXPECT_EQ(conn, nullptr);
+    EXPECT_EQ(graph->ConnectionCount(), 0);
 }
 
 TEST(GraphTest, DistinguishNodes)


### PR DESCRIPTION
## Summary
- `CanConnectNode` (added in #21) verified port existence but skipped type compatibility, so heterogeneous edges (e.g. `bool` → `std::string`) were silently accepted by `ConnectNodes` and surfaced later as crashes/UB at `Compute` time.
- Fix consults the existing conversion registry via `Env::GetFactory()->IsConvertible(...)` so registered conversions (`int ↔ int64_t`, chrono units, etc. that `Env::Create` pre-registers) keep working while genuinely mismatched pairs are rejected.
- Drops a stray `std::cout << "CanConnect"` debug print + `<iostream>` include left over from #21.

Deferred to a follow-up: cycle detection, self-loop rejection, and a rejection-reason enum for editor UX.

## Test plan
- [x] `flow_core_tests` — 30/30 pass on `GraphTest`/`FactoryTest`/`IndexableNameTest`/`NodeTest`/`TypeNameTest`
- [x] `CanConnectNode_AcceptsMatchingTypes` — int/bool/string/double same-type pairs accepted
- [x] `CanConnectNode_RejectsHeterogeneousTypes` — bool↔string, string↔double, double↔bool rejected
- [x] `CanConnectNode_AcceptsRegisteredConversion` — `int ↔ int64_t` still accepted via the `Env::Create` mesh (this case fails under a strict-equality fix)
- [x] `ConnectNodes_RejectsHeterogeneousPair` — mutation path returns `nullptr`, `ConnectionCount` stays 0
- [ ] Pre-existing `ModuleTest.*` failures reproduce on a clean clone of `main` (unrelated, working-directory lookup of `test_module.fmod`) — not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)