### PR TITLE
Validate input in UUIDFromString and add gtest coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 .vscode/
 build/
+build_test/
 
 # Cabin package build directory
 /cabin-out

--- a/src/UUID.cpp
+++ b/src/UUID.cpp
@@ -90,10 +90,16 @@ std::array<std::byte, 16> GenerateUUID()
 
 std::array<std::byte, 16> UUIDFromString(const std::string& uuid_str)
 {
-    auto uuid_cfstr = CFStringCreateWithCStringNoCopy(nullptr, uuid_str.c_str(), kCFStringEncodingASCII, nullptr);
+    auto uuid_cfstr = CFStringCreateWithCStringNoCopy(nullptr, uuid_str.c_str(), kCFStringEncodingASCII, kCFAllocatorNull);
     auto uuid       = CFUUIDCreateFromString(nullptr, uuid_cfstr);
-    auto bytes      = CFUUIDGetUUIDBytes(uuid);
+    if (uuid == nullptr)
+    {
+        CFRelease(uuid_cfstr);
+        throw std::invalid_argument("Bad UUID string: " + uuid_str);
+    }
+    auto bytes = CFUUIDGetUUIDBytes(uuid);
     CFRelease(uuid);
+    CFRelease(uuid_cfstr);
     return std::bit_cast<std::array<std::byte, 16>>(bytes);
 }
 #else
@@ -106,8 +112,11 @@ std::array<std::byte, 16> GenerateUUID()
 
 std::array<std::byte, 16> UUIDFromString(const std::string& uuid_str)
 {
-    uuid_t id;
-    uuid_parse(uuid_str.c_str(), id);
+    uuid_t id = {};
+    if (uuid_parse(uuid_str.c_str(), id) != 0)
+    {
+        throw std::invalid_argument("Bad UUID string: " + uuid_str);
+    }
     return std::bit_cast<std::array<std::byte, 16>>(id);
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   node_test.cpp
   type_name_test.cpp
   module_test.cpp
+  uuid_test.cpp
 )
 
 if(MSVC)

--- a/tests/uuid_test.cpp
+++ b/tests/uuid_test.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2024, Cisco Systems, Inc.
+// All rights reserved.
+
+#include "flow/core/UUID.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+using namespace flow;
+
+// -------------------------------------------------------------------------
+// Positive cases
+// -------------------------------------------------------------------------
+
+TEST(UUIDTest, DefaultConstruction_DoesNotThrow)
+{
+    ASSERT_NO_THROW(UUID{});
+}
+
+TEST(UUIDTest, WellFormedString_RoundTrips)
+{
+    const std::string canonical = "4bb1696d-30d1-41d2-aa19-0edf0560a951";
+    UUID uuid(canonical);
+    EXPECT_EQ(static_cast<std::string>(uuid), canonical);
+}
+
+TEST(UUIDTest, WellFormedString_AllLowercase_RoundTrips)
+{
+    // The toString() path uses lowercase hex; verify another well-formed UUID
+    const std::string canonical = "550e8400-e29b-41d4-a716-446655440000";
+    UUID uuid(canonical);
+    EXPECT_EQ(static_cast<std::string>(uuid), canonical);
+}
+
+// -------------------------------------------------------------------------
+// Negative cases — all must throw std::invalid_argument
+// -------------------------------------------------------------------------
+
+TEST(UUIDTest, EmptyString_ThrowsInvalidArgument)
+{
+    EXPECT_THROW(UUID(""), std::invalid_argument);
+}
+
+TEST(UUIDTest, NotAUUID_ThrowsInvalidArgument)
+{
+    EXPECT_THROW(UUID("not-a-uuid"), std::invalid_argument);
+}
+
+TEST(UUIDTest, GarbageInteriorChars_ThrowsInvalidArgument)
+{
+    // Correct length and hyphen positions, but non-hex interior characters.
+    // This is the Linux regression: before the fix uuid_parse returned nonzero
+    // but the discarded return value let garbage stack bytes through silently.
+    EXPECT_THROW(UUID("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"), std::invalid_argument);
+}
+
+TEST(UUIDTest, TooShort_ThrowsInvalidArgument)
+{
+    EXPECT_THROW(UUID("4bb1696d-30d1-41d2"), std::invalid_argument);
+}
+
+TEST(UUIDTest, TooLong_ThrowsInvalidArgument)
+{
+    EXPECT_THROW(UUID("4bb1696d-30d1-41d2-aa19-0edf0560a951-extra"), std::invalid_argument);
+}
+
+TEST(UUIDTest, MalformedHyphens_ThrowsInvalidArgument)
+{
+    // Right hex chars but hyphens in wrong places
+    EXPECT_THROW(UUID("4bb1696d30d1-41d2-aa19-0edf0560a951"), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary
- Fixes silent failures in `UUIDFromString` on both Linux and macOS paths — both now throw `std::invalid_argument` on malformed input
- Linux: `uuid_parse`'s return value was discarded, so bad input left `uuid_t` uninitialized and `bit_cast` returned stack garbage
- macOS: `CFUUIDCreateFromString` could return null (passed straight into `CFUUIDGetUUIDBytes`), the `CFString` was leaked, and the `CStringNoCopy` deallocator was the default system allocator (would try to free a `std::string`-owned buffer) — now uses `kCFAllocatorNull` with a matching `CFRelease`
- Adds `tests/uuid_test.cpp` with round-trip and malformed-input cases, registers it in the test executable, and gitignores the local `build_test/` dir

## Test plan
- [ ] Configure with `-Dflow-core_BUILD_TESTS=ON` and run the suite on Linux
- [ ] Run the suite on macOS to confirm the CF-path fixes
- [ ] Verify the `GarbageInteriorChars` case (the regression that motivated this) throws instead of returning a garbage UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)