### PR TITLE
fix(Port): replace SharedNodeData on type mismatch; make ModuleTest C…

### DIFF
--- a/src/Port.cpp
+++ b/src/Port.cpp
@@ -34,7 +34,16 @@ void Port::SetData(SharedNodeData data, bool output)
         return;
     }
 
-    if (!_data || !data || output)
+    // In-place value update preserves _data identity (downstream weak_ptrs
+    // and observers keep their handle), but is only valid when the incoming
+    // data is the SAME concrete type as the existing storage.  FromPointer
+    // does `*reinterpret_cast<T*>(other_ptr)` (NodeData.hpp), which silently
+    // reads the wrong number of bytes when widths differ — e.g. writing a
+    // NodeData<double> to a NodeData<float> port reads only the low 4 bytes
+    // of the double, so 440.0 (0x407B800000000000) becomes +0.0f.  On a
+    // type mismatch, replace the SharedNodeData instead.  Identity is lost
+    // for that single transition, but values are preserved correctly.
+    if (!_data || !data || output || _data->Type() != data->Type())
     {
         _data = std::move(data);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,15 @@ target_include_directories(${TEST_EXE} PRIVATE
   ${thread_pool_SOURCE_DIR}/include
 )
 
+# Bake the test_module.fmod path into the test binary so module_test.cpp does
+# not depend on the runtime CWD (gtest_discover_tests sets WORKING_DIRECTORY,
+# but a direct binary invocation needs the path resolved at compile time).
+# The .fmod is copied to $<TARGET_FILE_DIR:${TEST_EXE}> by the test_module
+# subdir's POST_BUILD step below.
+target_compile_definitions(${TEST_EXE} PRIVATE
+  FLOW_CORE_TEST_MODULE_FMOD_PATH="$<TARGET_FILE_DIR:${TEST_EXE}>/test_module.fmod"
+)
+
 if(MSVC)
   add_custom_command(TARGET flow_core_tests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/tests/module_test.cpp
+++ b/tests/module_test.cpp
@@ -12,7 +12,12 @@
 
 using namespace flow;
 
-const std::filesystem::path module_path = std::filesystem::current_path() / "test_module.fmod";
+// FLOW_CORE_TEST_MODULE_FMOD_PATH is set by tests/CMakeLists.txt to the absolute
+// path of the test_module.fmod produced alongside the test binary.  Using a
+// compile-time absolute path makes ModuleTest CWD-independent (it used to be
+// std::filesystem::current_path() / "test_module.fmod", which only worked when
+// the binary was invoked from inside the build dir).
+const std::filesystem::path module_path = FLOW_CORE_TEST_MODULE_FMOD_PATH;
 
 auto factory = std::make_shared<NodeFactory>();
 auto env     = Env::Create(factory);

--- a/tests/port_test.cpp
+++ b/tests/port_test.cpp
@@ -73,6 +73,43 @@ TEST(PortTest, SetDataReplacesWhenOutputFlagSet)
     EXPECT_NE(p.GetData().get(), prev_raw);
 }
 
+TEST(PortTest, SetDataReplacesOnTypeMismatch)
+{
+    // Regression: writing a NodeData<double> into a NodeData<float> port
+    // previously fell into the in-place FromPointer branch, which
+    // reinterpret_cast'd the incoming double pointer as a float*, reading
+    // only the low 4 bytes and silently corrupting the value.
+    //
+    // Specifically: 440.0 as IEEE-754 double is 0x407B800000000000.
+    // The low 4 bytes (little-endian) are 0x00000000, which is +0.0f
+    // when reinterpret_cast'd as float — completely losing the value.
+    //
+    // SetData must REPLACE the SharedNodeData on type mismatch so the
+    // incoming value is preserved correctly, at the cost of changing
+    // _data's identity for that single transition.
+    auto initial = MakeNodeData<float>(1.0f);
+    Port p(IndexableName{"k"}, "", "float", initial, false, 0);
+    auto prev_raw = p.GetData().get();
+
+    // Type mismatch: double (8 bytes) into a float-typed port (4 bytes).
+    p.SetData(MakeNodeData<double>(440.0));
+
+    // Identity changes (replaced, not in-place).
+    EXPECT_NE(p.GetData().get(), prev_raw);
+
+    // Value preserved correctly — no byte-level corruption.  Reading as
+    // the actual stored type (double) returns 440.0 unchanged; reading
+    // as the previous-port type (float) returns null because the
+    // dynamic_pointer_cast fails (which is the correct, observable
+    // signal that the type changed, far better than silent zeroing).
+    auto as_double = CastNodeData<double>(p.GetData());
+    ASSERT_NE(as_double, nullptr);
+    EXPECT_DOUBLE_EQ(as_double->Get(), 440.0);
+
+    auto as_float = CastNodeData<float>(p.GetData());
+    EXPECT_EQ(as_float, nullptr);
+}
+
 TEST(PortTest, SetDataRejectsNullForRequired)
 {
     auto initial = MakeNodeData<int>(5);

--- a/tests/test_module/CMakeLists.txt
+++ b/tests/test_module/CMakeLists.txt
@@ -25,6 +25,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/FlowModule.cmake)
 CreateFlowModule(${PROJECT_NAME})
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/test_module.fmod ${CMAKE_BINARY_DIR}/tests
-  COMMENT "Copy ${CMAKE_CURRENT_BINARY_DIR}/test_module.fmod to ${CMAKE_BINARY_DIR}/tests"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_BINARY_DIR}/test_module.fmod
+    $<TARGET_FILE_DIR:flow_core_tests>/test_module.fmod
+  COMMENT "Copy ${CMAKE_CURRENT_BINARY_DIR}/test_module.fmod next to flow_core_tests binary"
 )


### PR DESCRIPTION
…WD-independent

The bug
=======
Port::SetData's in-place value-update path calls FromPointer (NodeData.hpp), which does *reinterpret_cast<T*>(other_ptr).  When the incoming data is a different concrete type than the existing storage, this reads the wrong number of bytes and silently corrupts the value.

Concrete trigger: writing NodeData<double>(440.0) into a NodeData<float>
port.  440.0 as IEEE-754 double is 0x407B800000000000; the low 4 bytes (little-endian) are 0x00000000, reinterpreted as float = +0.0f.  Any binding that marshals a Dart double / Python float / etc. into a C++ float-typed port hits this trap silently.

The fix
=======
Extend Port::SetData's "REPLACE" predicate to include
  _data->Type() != data->Type()
When types match, in-place copy as before (preserves _data identity for downstream weak_ptrs).  When they differ, replace the SharedNodeData so the value is preserved correctly.  Identity is lost for that single transition; correctness trumps identity preservation on a type mismatch.

Regression test (port_test.cpp)
===============================
Adds PortTest.SetDataReplacesOnTypeMismatch covering the specific double-into-float case.  Asserts:
  - identity changes (REPLACE branch taken)
  - value preserved (440.0 still 440.0, not 0.0)
  - the new value is readable as its actual type (double)
  - cast to the old type (float) returns null, which is the correct, observable signal that the port's type changed — far better than silent zeroing.

ModuleTest CWD-independence (collateral)
========================================
ModuleTest used std::filesystem::current_path() / "test_module.fmod" to locate its fixture, which only worked when ctest set WORKING_DIRECTORY. Direct binary invocation from any other CWD failed all 6 ModuleTest cases with "Path does not exist."

Replaced with a compile-time absolute path baked in by CMake:
  target_compile_definitions(... FLOW_CORE_TEST_MODULE_FMOD_PATH="...")
Works whether the binary is run via ctest or directly, from any CWD.

Verification
============
Full test suite (run from /tmp to exercise the CWD-independence):
  153 PASSED, 3 SKIPPED, 0 FAILED.
The 6 previously-failing ModuleTest cases now pass.